### PR TITLE
Replace ScreenName annotation with custom implementation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+v3.0.0
+------
+ - Loggers no longer require android resources as a dependency.
+ - New `LogName` annotation used instead of the old `ScreenName` in order to
+   decouple the logged statements from the user-displayed name.
+
 v2.0.0
 ------
  - Added new logger types

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'android-maven'
 apply plugin: 'optional-base'
 
 group 'com.github.InkApplications'
-version 'v2.0.0'
+version 'v3.0.0'
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
 
@@ -41,5 +41,4 @@ repositories {
 }
 dependencies {
     compile 'com.google.android.gms:play-services:6.5.87', optional
-    compile 'com.github.InkApplications:Prism:v1.0.0'
 }

--- a/src/main/java/com/inkapplications/android/logger/LogName.java
+++ b/src/main/java/com/inkapplications/android/logger/LogName.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2015 Ink Applications, LLC.
+ * Distributed under the MIT License (http://opensource.org/licenses/MIT)
+ */
+package com.inkapplications.android.logger;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Defines a loggable string name for a class to be used if that object is
+ * logged as an individual log statement.
+ *
+ * @author Maxwell Vandervelde (Max@MaxVandervelde.com)
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface LogName
+{
+    /**
+     * The name of the class to be used in a logger.
+     */
+    String value();
+}

--- a/src/main/java/com/inkapplications/android/logger/analytics/AnalyticsLogger.java
+++ b/src/main/java/com/inkapplications/android/logger/analytics/AnalyticsLogger.java
@@ -4,21 +4,18 @@
  */
 package com.inkapplications.android.logger.analytics;
 
-import android.content.res.Resources;
 import com.google.android.gms.analytics.HitBuilders;
 import com.google.android.gms.analytics.Tracker;
+import com.inkapplications.android.logger.LogName;
 import org.apache.commons.logging.Log;
-import prism.framework.DisplayName;
 
 final public class AnalyticsLogger implements Log
 {
     final private Tracker analyticsTracker;
-    final private Resources resources;
 
-    public AnalyticsLogger(Tracker analyticsTracker, Resources resources)
+    public AnalyticsLogger(Tracker analyticsTracker)
     {
         this.analyticsTracker = analyticsTracker;
-        this.resources = resources;
     }
 
     @Override
@@ -99,7 +96,7 @@ final public class AnalyticsLogger implements Log
     @Override
     public void trace(Object o)
     {
-        if (o.getClass().isAnnotationPresent(DisplayName.class)) {
+        if (o.getClass().isAnnotationPresent(LogName.class)) {
             this.logScreen(o);
             return;
         }
@@ -142,16 +139,16 @@ final public class AnalyticsLogger implements Log
      * ScreenName annotation.
      *
      * @param o The object containing a DisplayName annotation to be logged.
-     * @see DisplayName
+     * @see com.inkapplications.android.logger.LogName
      */
     private void logScreen(Object o)
     {
-        DisplayName annotation = o.getClass().getAnnotation(DisplayName.class);
+        LogName annotation = o.getClass().getAnnotation(LogName.class);
         if (null == annotation) {
             return;
         }
 
-        String name = this.resources.getString(annotation.value());
+        String name = annotation.value();
         this.analyticsTracker.setScreenName(name);
         this.analyticsTracker.send(new HitBuilders.AppViewBuilder().build());
     }

--- a/src/main/java/com/inkapplications/android/logger/console/ConsoleLogger.java
+++ b/src/main/java/com/inkapplications/android/logger/console/ConsoleLogger.java
@@ -4,9 +4,8 @@
  */
 package com.inkapplications.android.logger.console;
 
-import android.content.res.Resources;
 import android.util.Log;
-import prism.framework.DisplayName;
+import com.inkapplications.android.logger.LogName;
 
 /**
  * Logs to Android's static Logcat logger.
@@ -18,9 +17,6 @@ import prism.framework.DisplayName;
  */
 public class ConsoleLogger extends EnvironmentAwareLogger
 {
-    /** Android resources service for looking up message strings. */
-    final private Resources resources;
-
     /** The tag used on the Android logger on all messages. */
     final private String loggerTag;
 
@@ -28,7 +24,6 @@ public class ConsoleLogger extends EnvironmentAwareLogger
     final private boolean sensitive;
 
     /**
-     * @param resources Android resources service for looking up message strings.
      * @param isDebug Changes whether low-level messages should be displayed.
      *                This should be false when the application is in production.
      * @param isSensitive Whether the application should crash on error/fatal
@@ -37,14 +32,12 @@ public class ConsoleLogger extends EnvironmentAwareLogger
      * @param loggerTag The tag used on the Android logger on all messages.
      */
     public ConsoleLogger(
-        Resources resources,
         boolean isDebug,
         boolean isSensitive,
         String loggerTag
     ) {
         super(isDebug);
 
-        this.resources = resources;
         this.loggerTag = loggerTag;
         this.sensitive = isSensitive;
     }
@@ -190,9 +183,8 @@ public class ConsoleLogger extends EnvironmentAwareLogger
             return "null";
         }
 
-        if (logged.getClass().isAnnotationPresent(DisplayName.class)) {
-            int resource = logged.getClass().getAnnotation(DisplayName.class).value();
-            return this.resources.getString(resource);
+        if (logged.getClass().isAnnotationPresent(LogName.class)) {
+            return logged.getClass().getAnnotation(LogName.class).value();
         }
 
         return logged.toString();


### PR DESCRIPTION
Since the ScreenName annotation is intended to be used for user-displayable
information and that may not be desirable as the logged name in the logger,
or particularly in analytics, the annotation has been removed and
replaced with a custom implementation.
Since that implementation did not require i18n, we can accept a plain
string as the value, eliminating our need to require android Resources
as a dependency as well as Prism . This change causes a BC break.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Fixed tickets | N/A |
